### PR TITLE
feat!: rename to expo-download, modernize for Expo SDK 54+, fix consumer install failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@
 ## Installation
 
 ```sh
-npm install expodl
+npx expo install expodl expo-file-system expo-media-library
 ```
+
+`expo-file-system` and `expo-media-library` are peer dependencies — installing them with `npx expo install` ensures the versions match your Expo SDK.
 
 ## Quick Start
 
@@ -64,11 +66,21 @@ await download('https://api.example.com/protected/file.pdf');
 
 ```typescript
 const { download } = useDownload({
-  cache: true,
-  overwrite: false, // Skip if already exists
+  cache: true, // Reuse the file if it already exists
 });
 
 await download('https://example.com/avatar.jpg');
+```
+
+### Save to Gallery
+
+```typescript
+const { download } = useDownload({
+  saveToGallery: true, // Off by default
+  albumName: 'My Photos',
+});
+
+await download('https://example.com/photo.jpg');
 ```
 
 ### Function API (Advanced)
@@ -85,9 +97,19 @@ const result = await downloadFile({
 
 ## Requirements
 
-- Expo SDK 47+ (tested up to SDK 53)
-- React Native 0.70+ (tested up to 0.81)
-- React 17+
+- Expo SDK 54+ (`expo-file-system` 19+, `expo-media-library` 17+)
+- React Native 0.76+
+- React 18+
+
+For Expo SDK 53 and below, use `expodl@1.x`.
+
+## Migrating from 1.x
+
+- **`saveToGallery` now defaults to `false`.** Downloads land in the app's document directory unless you opt in. Pass `saveToGallery: true` to keep the old behavior (media files only).
+- **`overwrite` option removed.** `cache: true` alone now reuses an existing file; omit it to always re-download.
+- **`expo-file-system` and `expo-media-library` are peer dependencies.** Install them in your app with `npx expo install`.
+- **`cancel()` now actually cancels** the underlying download (previously it only paused), and the pending `download()` promise rejects with code `CANCELLED`.
+- **`DownloadResult.size` removed** (it was never populated).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# expodl
+# expo-download
 
 > Lightweight Expo file download utility with caching, cancellation, and headers support.
 
-[![npm version](https://badge.fury.io/js/expodl.svg)](https://www.npmjs.com/package/expodl)
-[![npm downloads](https://img.shields.io/npm/dm/expodl.svg)](https://www.npmjs.com/package/expodl)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/expodl)](https://bundlephobia.com/package/expodl)
-[![license](https://img.shields.io/npm/l/expodl.svg)](https://github.com/pavankommi/expodl/blob/main/LICENSE)
+[![npm version](https://badge.fury.io/js/expo-download.svg)](https://www.npmjs.com/package/expo-download)
+[![npm downloads](https://img.shields.io/npm/dm/expo-download.svg)](https://www.npmjs.com/package/expo-download)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/expo-download)](https://bundlephobia.com/package/expo-download)
+[![license](https://img.shields.io/npm/l/expo-download.svg)](https://github.com/pavankommi/expo-download/blob/main/LICENSE)
 
 ## Features
 
@@ -17,7 +17,7 @@
 ## Installation
 
 ```sh
-npx expo install expodl expo-file-system expo-media-library
+npx expo install expo-download expo-file-system expo-media-library
 ```
 
 `expo-file-system` and `expo-media-library` are peer dependencies — installing them with `npx expo install` ensures the versions match your Expo SDK.
@@ -25,7 +25,7 @@ npx expo install expodl expo-file-system expo-media-library
 ## Quick Start
 
 ```typescript
-import { useDownload } from 'expodl';
+import { useDownload } from 'expo-download';
 
 export default function App() {
   const { download, isDownloading, progress, cancel } = useDownload();
@@ -86,7 +86,7 @@ await download('https://example.com/photo.jpg');
 ### Function API (Advanced)
 
 ```typescript
-import { downloadFile } from 'expodl';
+import { downloadFile } from 'expo-download';
 
 const result = await downloadFile({
   url: 'https://example.com/file.pdf',
@@ -101,10 +101,11 @@ const result = await downloadFile({
 - React Native 0.76+
 - React 18+
 
-For Expo SDK 53 and below, use `expodl@1.x`.
+For Expo SDK 53 and below, use `expodl@1.x` (this package's previous name).
 
 ## Migrating from 1.x
 
+- **Package renamed from `expodl` to `expo-download`.** Uninstall `expodl` and install `expo-download`; imports change accordingly.
 - **`saveToGallery` now defaults to `false`.** Downloads land in the app's document directory unless you opt in. Pass `saveToGallery: true` to keep the old behavior (media files only).
 - **`overwrite` option removed.** `cache: true` alone now reuses an existing file; omit it to always re-download.
 - **`expo-file-system` and `expo-media-library` are peer dependencies.** Install them in your app with `npx expo install`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,12 +29,11 @@ Default options applied to all downloads. Can be overridden per download.
 
 ```typescript
 interface UseDownloadOptions {
-  saveToGallery?: boolean;          // Save to device gallery (default: true)
+  saveToGallery?: boolean;          // Save to device gallery (default: false)
   albumName?: string;               // Album name (default: 'Download')
   fileName?: string;                // Custom filename
   headers?: Record<string, string>; // Custom HTTP headers
-  cache?: boolean;                  // Enable caching (default: false)
-  overwrite?: boolean;              // Overwrite cached files (default: true)
+  cache?: boolean;                  // Reuse existing file (default: false)
 }
 ```
 
@@ -97,7 +96,7 @@ Can accept either a string URL (for simple downloads) or a full options object.
 
 ```typescript
 await downloadFile('https://example.com/image.jpg');
-// Equivalent to: downloadFile({ url: '...', saveToGallery: true })
+// Equivalent to: downloadFile({ url: '...' })
 ```
 
 #### Options Object
@@ -106,11 +105,10 @@ await downloadFile('https://example.com/image.jpg');
 interface DownloadOptions {
   url: string;                           // Required: URL to download
   fileName?: string;                     // Optional: Custom filename
-  saveToGallery?: boolean;              // Optional: Save to gallery (default: true)
+  saveToGallery?: boolean;              // Optional: Save to gallery (default: false)
   albumName?: string;                   // Optional: Album name (default: 'Download')
   headers?: Record<string, string>;     // Optional: Custom HTTP headers
-  cache?: boolean;                      // Optional: Enable caching (default: false)
-  overwrite?: boolean;                  // Optional: Overwrite cached (default: true)
+  cache?: boolean;                      // Optional: Reuse existing file (default: false)
   onProgress?: (progress: number) => void; // Optional: Progress callback (0-1)
 }
 ```
@@ -122,7 +120,6 @@ interface DownloadResult {
   uri: string;           // Local file URI (file://...)
   fileName: string;      // File name
   mimeType: string | null; // Detected MIME type
-  size?: number;         // File size in bytes
   cached?: boolean;      // Whether file was served from cache
 }
 ```
@@ -178,7 +175,6 @@ interface DownloadOptions {
   albumName?: string;
   headers?: Record<string, string>;
   cache?: boolean;
-  overwrite?: boolean;
   onProgress?: (progress: number) => void;
 }
 ```
@@ -187,11 +183,10 @@ interface DownloadOptions {
 |----------|------|---------|-------------|
 | `url` | `string` | **Required** | URL to download |
 | `fileName` | `string` | Auto-generated | Custom filename |
-| `saveToGallery` | `boolean` | `true` | Save to device gallery |
+| `saveToGallery` | `boolean` | `false` | Save to device gallery |
 | `albumName` | `string` | `'Download'` | Gallery album name |
 | `headers` | `Record<string, string>` | `undefined` | Custom HTTP headers |
-| `cache` | `boolean` | `false` | Enable file caching |
-| `overwrite` | `boolean` | `true` | Overwrite existing cached files |
+| `cache` | `boolean` | `false` | Reuse existing file instead of re-downloading |
 | `onProgress` | `(progress: number) => void` | `undefined` | Progress callback (0-1) |
 
 ### DownloadResult
@@ -203,7 +198,6 @@ interface DownloadResult {
   uri: string;
   fileName: string;
   mimeType: string | null;
-  size?: number;
   cached?: boolean;
 }
 ```
@@ -213,7 +207,6 @@ interface DownloadResult {
 | `uri` | `string` | Local file URI (file://...) |
 | `fileName` | `string` | Downloaded file name |
 | `mimeType` | `string \| null` | Detected MIME type |
-| `size` | `number` | File size in bytes (optional) |
 | `cached` | `boolean` | `true` if loaded from cache |
 
 ### UseDownloadOptions
@@ -227,7 +220,6 @@ interface UseDownloadOptions {
   fileName?: string;
   headers?: Record<string, string>;
   cache?: boolean;
-  overwrite?: boolean;
 }
 ```
 
@@ -421,10 +413,9 @@ await download(url, {
 Skip re-downloading files:
 
 ```typescript
-// Enable caching, don't overwrite existing
+// Reuse the file if it already exists on disk
 const { download } = useDownload({
-  cache: true,
-  overwrite: false
+  cache: true
 });
 
 await download('https://example.com/avatar.jpg', {

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete API documentation for expodl.
+Complete API documentation for expo-download.
 
 ## Table of Contents
 
@@ -131,7 +131,7 @@ Throws `DownloadError` with specific error codes. See [Error Handling](#error-ha
 ### Example
 
 ```typescript
-import { downloadFile } from 'expodl';
+import { downloadFile } from 'expo-download';
 
 // Simple download
 const result = await downloadFile('https://example.com/image.jpg');
@@ -148,7 +148,6 @@ const result = await downloadFile({
     'X-Custom-Header': 'value'
   },
   cache: true,
-  overwrite: false,
   onProgress: (progress) => {
     console.log(`${Math.round(progress * 100)}%`);
   }
@@ -296,7 +295,7 @@ try {
 **With Function:**
 
 ```typescript
-import { downloadFile, DownloadError } from 'expodl';
+import { downloadFile, DownloadError } from 'expo-download';
 
 try {
   await downloadFile('https://example.com/file.pdf');
@@ -323,7 +322,7 @@ try {
 
 ## Supported File Types
 
-expodl automatically detects MIME types for common file extensions:
+expo-download automatically detects MIME types for common file extensions:
 
 | Extension | MIME Type |
 |-----------|-----------|

--- a/docs/api.md
+++ b/docs/api.md
@@ -275,6 +275,7 @@ class DownloadError extends Error {
 | `DOWNLOAD_FAILED` | Network or download error | Network issues, 404, server error |
 | `PERMISSION_DENIED` | Media library permission denied | User denied permission |
 | `CANCELLED` | Download was cancelled | User called `cancel()` |
+| `UNAVAILABLE` | No writable document directory | Running on web |
 | `UNKNOWN_ERROR` | Other errors | Unexpected errors |
 
 ### Handling Errors

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,7 +11,7 @@ Advanced usage examples for expodl.
 - [Error Handling](#error-handling)
 - [Download List with Progress](#download-list-with-progress)
 - [Custom Album and Filename](#custom-album-and-filename)
-- [Download without Gallery Save](#download-without-gallery-save)
+- [Save to Gallery](#save-to-gallery)
 
 ---
 
@@ -87,8 +87,7 @@ import { useDownload } from 'expodl';
 
 function CachedDownload() {
   const { download, result } = useDownload({
-    cache: true,
-    overwrite: false  // Don't re-download if exists
+    cache: true  // Reuse the file if it already exists
   });
 
   const handleDownload = async () => {
@@ -251,13 +250,14 @@ function DownloadList() {
 
 ## Custom Album and Filename
 
-Organize downloads into specific albums with custom names:
+Organize gallery downloads into specific albums with custom names:
 
 ```typescript
 import { useDownload } from 'expodl';
 
 function OrganizedDownload() {
   const { download } = useDownload({
+    saveToGallery: true,
     albumName: 'My Vacation Photos'
   });
 
@@ -278,35 +278,33 @@ function OrganizedDownload() {
 
 ---
 
-## Download without Gallery Save
+## Save to Gallery
 
-Download files to app's document directory only:
+By default, files are saved only to the app's document directory. Opt in to also save media to the device gallery:
 
 ```typescript
 import { useDownload } from 'expodl';
 
-function TempDownload() {
+function GalleryDownload() {
   const { download, result } = useDownload();
 
   const handleDownload = async () => {
-    await download('https://example.com/temp.pdf', {
-      saveToGallery: false  // Only save to app directory
+    await download('https://example.com/photo.jpg', {
+      saveToGallery: true,
+      albumName: 'Downloads'
     });
 
-    // File is in app's document directory
-    console.log('Temp file:', result?.uri);
-    // Use the file (display, share, etc.)
+    console.log('Saved to gallery:', result?.uri);
   };
 
-  return <Button onPress={handleDownload}>Download Temporarily</Button>;
+  return <Button onPress={handleDownload}>Save to Gallery</Button>;
 }
 ```
 
-**Use cases:**
-- Temporary files that will be processed
-- Cache files
-- Files for immediate use (share, display)
-- Files that shouldn't clutter user's gallery
+**Notes:**
+- Requires media library permission (requested automatically)
+- Only use for media files (images, video, audio) — the media library rejects other file types like PDFs
+- Without `saveToGallery`, files stay in the app's document directory (good for temp files, caching, share sheets)
 
 ---
 
@@ -328,7 +326,6 @@ async function advancedDownload() {
       'Custom-Header': 'value'
     },
     cache: true,
-    overwrite: false,
     onProgress: (progress) => {
       console.log(`Download: ${Math.round(progress * 100)}%`);
     }
@@ -362,7 +359,6 @@ export default function DownloadManager() {
     reset
   } = useDownload({
     cache: true,
-    overwrite: false,
     headers: {
       'User-Agent': 'expodl-example'
     }

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-Advanced usage examples for expodl.
+Advanced usage examples for expo-download.
 
 ## Table of Contents
 
@@ -20,7 +20,7 @@ Advanced usage examples for expodl.
 Allow users to cancel downloads mid-flight:
 
 ```typescript
-import { useDownload } from 'expodl';
+import { useDownload } from 'expo-download';
 
 function DownloadWithCancel() {
   const { download, cancel, isDownloading, progress } = useDownload();
@@ -48,7 +48,7 @@ function DownloadWithCancel() {
 Download files from protected APIs:
 
 ```typescript
-import { useDownload } from 'expodl';
+import { useDownload } from 'expo-download';
 
 function AuthenticatedDownload() {
   const { download } = useDownload({
@@ -83,7 +83,7 @@ await download('https://api.example.com/file.pdf', {
 Avoid re-downloading files that already exist:
 
 ```typescript
-import { useDownload } from 'expodl';
+import { useDownload } from 'expo-download';
 
 function CachedDownload() {
   const { download, result } = useDownload({
@@ -119,7 +119,7 @@ function CachedDownload() {
 Track multiple downloads independently:
 
 ```typescript
-import { useDownload } from 'expodl';
+import { useDownload } from 'expo-download';
 
 function MultiDownload() {
   const images = useDownload();
@@ -150,7 +150,7 @@ function MultiDownload() {
 Properly handle download errors:
 
 ```typescript
-import { useDownload, DownloadError } from 'expodl';
+import { useDownload, DownloadError } from 'expo-download';
 
 function SafeDownload() {
   const { download, isDownloading, error, reset } = useDownload();
@@ -201,7 +201,7 @@ function SafeDownload() {
 Build a download manager:
 
 ```typescript
-import { useDownload } from 'expodl';
+import { useDownload } from 'expo-download';
 import { useState } from 'react';
 
 function DownloadList() {
@@ -253,7 +253,7 @@ function DownloadList() {
 Organize gallery downloads into specific albums with custom names:
 
 ```typescript
-import { useDownload } from 'expodl';
+import { useDownload } from 'expo-download';
 
 function OrganizedDownload() {
   const { download } = useDownload({
@@ -283,7 +283,7 @@ function OrganizedDownload() {
 By default, files are saved only to the app's document directory. Opt in to also save media to the device gallery:
 
 ```typescript
-import { useDownload } from 'expodl';
+import { useDownload } from 'expo-download';
 
 function GalleryDownload() {
   const { download, result } = useDownload();
@@ -313,7 +313,7 @@ function GalleryDownload() {
 For more control, use `downloadFile` directly:
 
 ```typescript
-import { downloadFile } from 'expodl';
+import { downloadFile } from 'expo-download';
 
 async function advancedDownload() {
   const result = await downloadFile({
@@ -346,7 +346,7 @@ Here's a full-featured download component:
 ```typescript
 import React, { useState } from 'react';
 import { View, Button, Text, ActivityIndicator, StyleSheet } from 'react-native';
-import { useDownload } from 'expodl';
+import { useDownload } from 'expo-download';
 
 export default function DownloadManager() {
   const {
@@ -360,7 +360,7 @@ export default function DownloadManager() {
   } = useDownload({
     cache: true,
     headers: {
-      'User-Agent': 'expodl-example'
+      'User-Agent': 'expo-download-example'
     }
   });
 

--- a/example/package.json
+++ b/example/package.json
@@ -9,14 +9,17 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "expo": "~47.0.7",
-    "expo-status-bar": "~1.4.2",
-    "react": "18.1.0",
-    "react-native": "0.70.5"
+    "expo": "~54.0.0",
+    "expo-file-system": "~19.0.23",
+    "expo-media-library": "~18.2.1",
+    "expo-status-bar": "~3.0.9",
+    "react": "19.1.0",
+    "react-native": "0.81.5"
   },
   "devDependencies": {
-    "@babel/core": "^7.12.9",
-    "babel-plugin-module-resolver": "^4.1.0"
+    "@babel/core": "^7.25.0",
+    "babel-plugin-module-resolver": "^5.0.0",
+    "babel-preset-expo": "~54.0.0"
   },
   "private": true
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,7 +7,7 @@ import {
   Button,
   ActivityIndicator,
 } from 'react-native';
-import { useDownload } from 'expodl';
+import { useDownload } from 'expo-download';
 
 export default function App() {
   const { download, cancel, isDownloading, progress, error, result, reset } =
@@ -19,7 +19,7 @@ export default function App() {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>expodl Example</Text>
+      <Text style={styles.title}>expo-download Example</Text>
       <Text style={styles.subtitle}>Download with cancellation</Text>
 
       {!isDownloading && !result && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,36 +7,34 @@
     "": {
       "name": "expodl",
       "version": "1.0.3",
-      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "expo-file-system": "^15.1.1",
-        "expo-media-library": "^15.0.0"
-      },
       "devDependencies": {
         "@react-native-community/eslint-config": "^3.0.2",
         "@react-native/babel-preset": "^0.82.1",
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^30.0.0",
-        "@types/react": "~18.0.0",
+        "@types/react": "~19.1.0",
         "@typescript-eslint/parser": "^8.46.2",
         "del-cli": "^7.0.0",
         "eslint": "^9.38.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
+        "expo-file-system": "^57.0.0",
+        "expo-media-library": "^57.0.1",
+        "expo-modules-core": "^57.0.3",
         "jest": "^30.2.0",
-        "patch-package": "^8.0.1",
-        "postinstall-postinstall": "^2.1.0",
         "prettier": "^3.6.2",
-        "react": "18.1.0",
+        "react": "19.1.0",
         "react-native": "0.81.4",
         "react-native-builder-bob": "^0.40.13",
-        "react-test-renderer": "18.1.0",
+        "react-test-renderer": "19.1.0",
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
-        "react": ">=17",
-        "react-native": ">=0.70"
+        "expo-file-system": ">=19.0.0",
+        "expo-media-library": ">=17.0.0",
+        "react": ">=18",
+        "react-native": ">=0.76"
       }
     },
     "node_modules/@ark/schema": {
@@ -2402,6 +2400,13 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@expo/expo-modules-macros-plugin": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@expo/expo-modules-macros-plugin/-/expo-modules-macros-plugin-0.3.0.tgz",
+      "integrity": "sha512-2tRq8kiIZTVZcI5uggh86HefQ7s++Zk5WkFFomNp4aUqyN5ownHHvj1jPEP9jWXaXjPDmWuf5SUZTGD5G6AKkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3944,31 +3949,15 @@
         "undici-types": "~7.16.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.38.tgz",
-      "integrity": "sha512-ExsidLLSzYj4cvaQjGnQCk4HFfVT9+EZ9XZsQ8Hsrcn8QNgXtpZ3m9vSIC2MWtx7jHictK6wYhQgGh6ic58oOw==",
+      "version": "19.1.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
+      "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -4845,13 +4834,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@yarnpkg/lockfile": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -6932,24 +6914,57 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "15.9.0",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-15.9.0.tgz",
-      "integrity": "sha512-ikzqBGpbSzp/57+aruXzRR2s0HEVYxdd1o3RxfswJRujjT/6X128xmUTTFDaQUr+zydyvxvY7Mo0szWpXhPyLA==",
+      "version": "57.0.0",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.0.tgz",
+      "integrity": "sha512-G+eytNuNGMiS7dbdj1j0nAYMowXnNr1vpO+jss6nQvBlRxshcGBFMtk8xfc67ynz0MUVkzod7WwKO7Vf1iOaJw==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "uuid": "^3.4.0"
-      },
       "peerDependencies": {
-        "expo": "*"
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-media-library": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-15.9.2.tgz",
-      "integrity": "sha512-ExRcCxNO768aWPQr9axuBDQLcFnRTSiqvWZ1XvnopCfZEic04wJ/CPAE1hLqTp7AyYrd6jHpqxa/aNKBAAFVeA==",
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-57.0.1.tgz",
+      "integrity": "sha512-j7u+0HtIjzdk/bvlKacy+75jqjpdz/3dAWkhL9j9NGqNOJeolW4XHjJWhq14y8vUF8Ih7nlayyse34KnRAnNmA==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "expo": "*"
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-modules-core": {
+      "version": "57.0.3",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.3.tgz",
+      "integrity": "sha512-fuD3DjPQvdaldtCJm2erV2/trPMrDJvEwPdz0RuxAQnduiNwZ3yxBoi81ZEKC5GBSJauMo53YXSwogsFagjwFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@expo/expo-modules-macros-plugin": "0.3.0",
+        "expo-modules-jsi": "~57.0.1",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-worklets": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-worklets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-modules-jsi": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-57.0.1.tgz",
+      "integrity": "sha512-dECN3pOFv+KrQcGrOhJKEBc1/ob7SBjTTYGRB1bc84zmQ65La0FSrAPxpvnEQf8g9giLB5y9RLqwGxHspjXigQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": "*"
       }
     },
     "node_modules/exponential-backoff": {
@@ -7114,16 +7129,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-yarn-workspace-root": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "micromatch": "^4.0.2"
       }
     },
     "node_modules/flat-cache": {
@@ -9404,26 +9409,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-stable-stringify": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
-      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "isarray": "^2.0.5",
-        "jsonify": "^0.0.1",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -9457,16 +9442,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "dev": true,
-      "license": "Public Domain",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -9491,16 +9466,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/klaw-sync": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -10435,16 +10400,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -10876,75 +10831,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/patch-package": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
-      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^4.1.2",
-        "ci-info": "^3.7.0",
-        "cross-spawn": "^7.0.3",
-        "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^10.0.0",
-        "json-stable-stringify": "^1.0.2",
-        "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.6",
-        "open": "^7.4.2",
-        "semver": "^7.5.3",
-        "slash": "^2.0.0",
-        "tmp": "^0.2.4",
-        "yaml": "^2.2.2"
-      },
-      "bin": {
-        "patch-package": "index.js"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">5"
-      }
-    },
-    "node_modules/patch-package/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/patch-package/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/patch-package/node_modules/slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11127,14 +11013,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/postinstall-postinstall": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz",
-      "integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -11349,14 +11227,11 @@
       }
     },
     "node_modules/react": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
-      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12166,44 +12041,26 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-shallow-renderer": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
-      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-test-renderer": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.1.0.tgz",
-      "integrity": "sha512-OfuueprJFW7h69GN+kr4Ywin7stcuqaYAt1g7airM5cUgP0BoF5G5CXsPGmXeDeEkncb2fqYNECO4y18sSqphg==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "react-is": "^18.1.0",
-        "react-shallow-renderer": "^16.15.0",
-        "scheduler": "^0.22.0"
+        "react-is": "^19.1.0",
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^18.1.0"
+        "react": "^19.1.0"
       }
     },
-    "node_modules/react-test-renderer/node_modules/scheduler": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
-      "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -13285,16 +13142,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -13686,16 +13533,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "expodl",
+  "name": "expo-download",
   "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "expodl",
+      "name": "expo-download",
       "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prepare": "bob build",
-    "postinstall": "patch-package",
     "release": "release-it",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn install"
@@ -61,32 +60,28 @@
     "@react-native/babel-preset": "^0.82.1",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
-    "@types/react": "~18.0.0",
+    "@types/react": "~19.1.0",
     "@typescript-eslint/parser": "^8.46.2",
     "del-cli": "^7.0.0",
     "eslint": "^9.38.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "expo-file-system": "^57.0.0",
+    "expo-media-library": "^57.0.1",
+    "expo-modules-core": "^57.0.3",
     "jest": "^30.2.0",
-    "patch-package": "^8.0.1",
-    "postinstall-postinstall": "^2.1.0",
     "prettier": "^3.6.2",
-    "react": "18.1.0",
+    "react": "19.1.0",
     "react-native": "0.81.4",
     "react-native-builder-bob": "^0.40.13",
-    "react-test-renderer": "18.1.0",
+    "react-test-renderer": "19.1.0",
     "typescript": "^5.9.3"
   },
-  "resolutions": {
-    "@types/react": "18.0.0"
-  },
-  "overrides": {
-    "react": "18.1.0",
-    "react-test-renderer": "18.1.0"
-  },
   "peerDependencies": {
-    "react": ">=17",
-    "react-native": ">=0.70"
+    "expo-file-system": ">=19.0.0",
+    "expo-media-library": ">=17.0.0",
+    "react": ">=18",
+    "react-native": ">=0.76"
   },
   "eslintConfig": {
     "root": true,
@@ -131,9 +126,5 @@
         }
       ]
     ]
-  },
-  "dependencies": {
-    "expo-file-system": "^15.1.1",
-    "expo-media-library": "^15.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "expodl",
+  "name": "expo-download",
   "version": "1.0.3",
   "description": "Lightweight Expo file download utility with caching, cancellation, and headers support.",
   "main": "lib/commonjs/index",
@@ -42,16 +42,18 @@
     "expo",
     "expo-react-native",
     "expodl",
+    "download",
+    "file-download",
     "expo-file-system",
     "expo-media-library"
   ],
-  "repository": "https://github.com/pavankommi/expodl",
+  "repository": "https://github.com/pavankommi/expo-download",
   "author": "pavankommi <pavankommi0503@gmail.com> (https://github.com/pavankommi)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/pavankommi/expodl/issues"
+    "url": "https://github.com/pavankommi/expo-download/issues"
   },
-  "homepage": "https://github.com/pavankommi/expodl#readme",
+  "homepage": "https://github.com/pavankommi/expo-download#readme",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react-native';
 import { downloadFile, DownloadError, useDownload } from '../index';
 
 // Mock expo modules
-jest.mock('expo-file-system', () => ({
+jest.mock('expo-file-system/legacy', () => ({
   documentDirectory: 'file:///mock/document/',
   createDownloadResumable: jest.fn(),
   getInfoAsync: jest.fn(),
@@ -16,7 +16,7 @@ jest.mock('expo-media-library', () => ({
   addAssetsToAlbumAsync: jest.fn(),
 }));
 
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import * as MediaLibrary from 'expo-media-library';
 
 describe('expodl', () => {
@@ -34,24 +34,27 @@ describe('expodl', () => {
         downloadAsync: mockDownloadAsync,
       });
 
-      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
-        status: 'granted',
-      });
-
-      (MediaLibrary.createAssetAsync as jest.Mock).mockResolvedValue({
-        id: 'asset-123',
-      });
-
-      (MediaLibrary.getAlbumAsync as jest.Mock).mockResolvedValue({
-        id: 'album-123',
-      });
-
       const result = await downloadFile('https://example.com/image.jpg');
 
       expect(result).toHaveProperty('uri');
       expect(result).toHaveProperty('fileName');
       expect(result).toHaveProperty('mimeType', 'image/jpeg');
       expect(mockDownloadAsync).toHaveBeenCalled();
+    });
+
+    it('should not touch the media library by default', async () => {
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/download_123.jpg',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      await downloadFile('https://example.com/image.jpg');
+
+      expect(MediaLibrary.requestPermissionsAsync).not.toHaveBeenCalled();
+      expect(MediaLibrary.createAssetAsync).not.toHaveBeenCalled();
     });
 
     it('should download file with options object', async () => {
@@ -61,10 +64,6 @@ describe('expodl', () => {
 
       (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
         downloadAsync: mockDownloadAsync,
-      });
-
-      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
-        status: 'granted',
       });
 
       const result = await downloadFile({
@@ -92,10 +91,6 @@ describe('expodl', () => {
         }
       );
 
-      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
-        status: 'granted',
-      });
-
       await downloadFile({
         url: 'https://example.com/video.mp4',
         onProgress,
@@ -104,7 +99,31 @@ describe('expodl', () => {
       expect(onProgress).toHaveBeenCalledWith(0.5);
     });
 
-    it('should skip gallery save when saveToGallery is false', async () => {
+    it('should skip progress updates when total size is unknown', async () => {
+      const onProgress = jest.fn();
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/test.mp4',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockImplementation(
+        (_url, _fileUri, _options, callback) => {
+          if (callback) {
+            // Server omitted Content-Length
+            callback({ totalBytesWritten: 50, totalBytesExpectedToWrite: -1 });
+          }
+          return { downloadAsync: mockDownloadAsync };
+        }
+      );
+
+      await downloadFile({
+        url: 'https://example.com/video.mp4',
+        onProgress,
+      });
+
+      expect(onProgress).not.toHaveBeenCalled();
+    });
+
+    it('should save to gallery when saveToGallery is true', async () => {
       const mockDownloadAsync = jest.fn().mockResolvedValue({
         uri: 'file:///mock/document/temp.jpg',
       });
@@ -113,22 +132,34 @@ describe('expodl', () => {
         downloadAsync: mockDownloadAsync,
       });
 
-      await downloadFile({
-        url: 'https://example.com/image.jpg',
-        saveToGallery: false,
+      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
       });
 
-      expect(MediaLibrary.requestPermissionsAsync).not.toHaveBeenCalled();
+      (MediaLibrary.createAssetAsync as jest.Mock).mockResolvedValue({
+        id: 'asset-123',
+      });
+
+      (MediaLibrary.getAlbumAsync as jest.Mock).mockResolvedValue({
+        id: 'album-123',
+      });
+
+      await downloadFile({
+        url: 'https://example.com/image.jpg',
+        saveToGallery: true,
+      });
+
+      expect(MediaLibrary.requestPermissionsAsync).toHaveBeenCalled();
+      expect(MediaLibrary.createAssetAsync).toHaveBeenCalled();
+      expect(MediaLibrary.addAssetsToAlbumAsync).toHaveBeenCalled();
     });
 
     it('should throw DownloadError when URL is missing', async () => {
-      await expect(
-        downloadFile({ url: '', saveToGallery: false })
-      ).rejects.toThrow(DownloadError);
+      await expect(downloadFile({ url: '' })).rejects.toThrow(DownloadError);
 
-      await expect(
-        downloadFile({ url: '', saveToGallery: false })
-      ).rejects.toThrow('URL is required');
+      await expect(downloadFile({ url: '' })).rejects.toThrow(
+        'URL is required'
+      );
     });
 
     it('should throw DownloadError when permission is denied', async () => {
@@ -145,7 +176,10 @@ describe('expodl', () => {
       });
 
       await expect(
-        downloadFile('https://example.com/image.jpg')
+        downloadFile({
+          url: 'https://example.com/image.jpg',
+          saveToGallery: true,
+        })
       ).rejects.toThrow('Media library permission denied');
     });
 
@@ -168,6 +202,7 @@ describe('expodl', () => {
 
       await downloadFile({
         url: 'https://example.com/image.jpg',
+        saveToGallery: true,
         albumName: 'Custom Album',
       });
 
@@ -187,10 +222,6 @@ describe('expodl', () => {
         downloadAsync: mockDownloadAsync,
       });
 
-      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
-        status: 'granted',
-      });
-
       const result = await downloadFile('https://example.com/image.webp');
       expect(result.mimeType).toBe('image/webp');
     });
@@ -206,10 +237,70 @@ describe('expodl', () => {
 
       const result = await downloadFile({
         url: 'https://example.com/image.jpg?version=2&token=abc',
-        saveToGallery: false,
       });
 
       expect(result.fileName).toMatch(/\.jpg$/);
+    });
+
+    it('should reuse existing file when cache is enabled', async () => {
+      const mockDownloadAsync = jest.fn();
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({
+        exists: true,
+      });
+
+      const result = await downloadFile({
+        url: 'https://example.com/image.jpg',
+        fileName: 'cached.jpg',
+        cache: true,
+      });
+
+      expect(result.cached).toBe(true);
+      expect(mockDownloadAsync).not.toHaveBeenCalled();
+    });
+
+    it('should download when cache is enabled but file does not exist', async () => {
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/test.jpg',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({
+        exists: false,
+      });
+
+      const result = await downloadFile({
+        url: 'https://example.com/image.jpg',
+        cache: true,
+      });
+
+      expect(result.cached).toBe(false);
+      expect(mockDownloadAsync).toHaveBeenCalled();
+    });
+
+    it('should always download when cache is disabled', async () => {
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/test.jpg',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      const result = await downloadFile({
+        url: 'https://example.com/image.jpg',
+      });
+
+      expect(FileSystem.getInfoAsync).not.toHaveBeenCalled();
+      expect(result.cached).toBe(false);
+      expect(mockDownloadAsync).toHaveBeenCalled();
     });
   });
 
@@ -236,18 +327,6 @@ describe('expodl', () => {
         downloadAsync: mockDownloadAsync,
       });
 
-      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
-        status: 'granted',
-      });
-
-      (MediaLibrary.createAssetAsync as jest.Mock).mockResolvedValue({
-        id: 'asset-123',
-      });
-
-      (MediaLibrary.getAlbumAsync as jest.Mock).mockResolvedValue({
-        id: 'album-123',
-      });
-
       const { result } = renderHook(() => useDownload());
 
       expect(result.current.isDownloading).toBe(false);
@@ -269,20 +348,14 @@ describe('expodl', () => {
       (FileSystem.createDownloadResumable as jest.Mock).mockImplementation(
         (_url, _fileUri, _options, callback) => {
           if (callback) {
-            setTimeout(() => {
-              callback({
-                totalBytesWritten: 50,
-                totalBytesExpectedToWrite: 100,
-              });
-            }, 10);
+            callback({
+              totalBytesWritten: 50,
+              totalBytesExpectedToWrite: 100,
+            });
           }
           return { downloadAsync: mockDownloadAsync };
         }
       );
-
-      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
-        status: 'granted',
-      });
 
       const { result } = renderHook(() => useDownload());
 
@@ -290,7 +363,7 @@ describe('expodl', () => {
         await result.current.download('https://example.com/image.jpg');
       });
 
-      // Progress tracking happens during download
+      expect(result.current.progress).toBe(0.5);
       expect(result.current.isDownloading).toBe(false);
     });
 
@@ -326,10 +399,6 @@ describe('expodl', () => {
         downloadAsync: mockDownloadAsync,
       });
 
-      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
-        status: 'granted',
-      });
-
       const { result } = renderHook(() => useDownload());
 
       await act(async () => {
@@ -361,6 +430,14 @@ describe('expodl', () => {
         status: 'granted',
       });
 
+      (MediaLibrary.createAssetAsync as jest.Mock).mockResolvedValue({
+        id: 'asset-123',
+      });
+
+      (MediaLibrary.getAlbumAsync as jest.Mock).mockResolvedValue({
+        id: 'album-123',
+      });
+
       const { result } = renderHook(() =>
         useDownload({ saveToGallery: true, albumName: 'MyAlbum' })
       );
@@ -369,6 +446,7 @@ describe('expodl', () => {
         await result.current.download('https://example.com/image.jpg');
       });
 
+      expect(MediaLibrary.getAlbumAsync).toHaveBeenCalledWith('MyAlbum');
       expect(result.current.result).not.toBe(null);
     });
 
@@ -392,21 +470,31 @@ describe('expodl', () => {
       expect(MediaLibrary.requestPermissionsAsync).not.toHaveBeenCalled();
     });
 
-    it('should support cancellation', () => {
-      const mockPauseAsync = jest.fn();
-      const mockDownloadAsync = jest.fn().mockImplementation(() => {
-        return new Promise(() => {}); // Never resolves
-      });
+    it('should support cancellation', async () => {
+      const mockCancelAsync = jest.fn().mockResolvedValue(undefined);
+      let rejectDownload: (err: Error) => void = () => {};
+      const mockDownloadAsync = jest.fn().mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectDownload = reject;
+          })
+      );
 
       (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
         downloadAsync: mockDownloadAsync,
-        pauseAsync: mockPauseAsync,
+        cancelAsync: mockCancelAsync,
       });
 
       const { result } = renderHook(() => useDownload());
 
+      let downloadPromise: Promise<void> = Promise.resolve();
       act(() => {
-        result.current.download('https://example.com/image.jpg');
+        downloadPromise = result.current.download(
+          'https://example.com/image.jpg'
+        );
+        downloadPromise.catch(() => {
+          // Expected rejection after cancel
+        });
       });
 
       expect(result.current.isDownloading).toBe(true);
@@ -415,8 +503,16 @@ describe('expodl', () => {
         result.current.cancel();
       });
 
-      expect(mockPauseAsync).toHaveBeenCalled();
+      expect(mockCancelAsync).toHaveBeenCalled();
       expect(result.current.isDownloading).toBe(false);
+      expect(result.current.error?.code).toBe('CANCELLED');
+
+      // Native cancellation rejects the pending download; the error stays CANCELLED
+      await act(async () => {
+        rejectDownload(new Error('Download cancelled by native module'));
+        await downloadPromise.catch(() => {});
+      });
+
       expect(result.current.error?.code).toBe('CANCELLED');
     });
 
@@ -433,7 +529,6 @@ describe('expodl', () => {
         await downloadFile({
           url: 'https://example.com/image.jpg',
           headers: { Authorization: 'Bearer token123' },
-          saveToGallery: false,
         });
       });
 
@@ -443,53 +538,6 @@ describe('expodl', () => {
         { headers: { Authorization: 'Bearer token123' } },
         undefined
       );
-    });
-
-    it('should use cache and skip download if file exists', async () => {
-      const mockDownloadAsync = jest.fn();
-
-      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
-        downloadAsync: mockDownloadAsync,
-      });
-
-      (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({
-        exists: true,
-      });
-
-      const result = await downloadFile({
-        url: 'https://example.com/image.jpg',
-        fileName: 'cached.jpg',
-        cache: true,
-        overwrite: false,
-        saveToGallery: false,
-      });
-
-      expect(result.cached).toBe(true);
-      expect(mockDownloadAsync).not.toHaveBeenCalled();
-    });
-
-    it('should download even with cache if overwrite is true', async () => {
-      const mockDownloadAsync = jest.fn().mockResolvedValue({
-        uri: 'file:///mock/document/test.jpg',
-      });
-
-      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
-        downloadAsync: mockDownloadAsync,
-      });
-
-      (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({
-        exists: true,
-      });
-
-      const result = await downloadFile({
-        url: 'https://example.com/image.jpg',
-        cache: true,
-        overwrite: true,
-        saveToGallery: false,
-      });
-
-      expect(result.cached).toBe(false);
-      expect(mockDownloadAsync).toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -2,8 +2,14 @@ import { renderHook, act } from '@testing-library/react-native';
 import { downloadFile, DownloadError, useDownload } from '../index';
 
 // Mock expo modules
-jest.mock('expo-file-system/legacy', () => ({
+const mockFileSystemState: { documentDirectory: string | null } = {
   documentDirectory: 'file:///mock/document/',
+};
+
+jest.mock('expo-file-system/legacy', () => ({
+  get documentDirectory() {
+    return mockFileSystemState.documentDirectory;
+  },
   createDownloadResumable: jest.fn(),
   getInfoAsync: jest.fn(),
 }));
@@ -302,6 +308,249 @@ describe('expodl', () => {
       expect(result.cached).toBe(false);
       expect(mockDownloadAsync).toHaveBeenCalled();
     });
+
+    it('should fall back to .bin extension and null MIME type for extensionless URLs', async () => {
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/download_123.bin',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      const result = await downloadFile('https://example.com/api/files/42');
+
+      expect(result.fileName).toMatch(/\.bin$/);
+      expect(result.mimeType).toBe(null);
+    });
+
+    it('should write files into documentDirectory', async () => {
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/report.pdf',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      await downloadFile({
+        url: 'https://example.com/report.pdf',
+        fileName: 'report.pdf',
+      });
+
+      expect(FileSystem.createDownloadResumable).toHaveBeenCalledWith(
+        'https://example.com/report.pdf',
+        'file:///mock/document/report.pdf',
+        {},
+        undefined
+      );
+    });
+
+    it('should throw UNAVAILABLE when documentDirectory is null', async () => {
+      mockFileSystemState.documentDirectory = null;
+
+      try {
+        await expect(
+          downloadFile('https://example.com/image.jpg')
+        ).rejects.toMatchObject({ code: 'UNAVAILABLE' });
+      } finally {
+        mockFileSystemState.documentDirectory = 'file:///mock/document/';
+      }
+    });
+
+    it('should clamp progress to 1 when written bytes exceed the expected total', async () => {
+      const onProgress = jest.fn();
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/test.mp4',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockImplementation(
+        (_url, _fileUri, _options, callback) => {
+          if (callback) {
+            callback({
+              totalBytesWritten: 150,
+              totalBytesExpectedToWrite: 100,
+            });
+          }
+          return { downloadAsync: mockDownloadAsync };
+        }
+      );
+
+      await downloadFile({
+        url: 'https://example.com/video.mp4',
+        onProgress,
+      });
+
+      expect(onProgress).toHaveBeenCalledWith(1);
+    });
+
+    it('should skip progress updates when the expected total is zero', async () => {
+      const onProgress = jest.fn();
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/test.mp4',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockImplementation(
+        (_url, _fileUri, _options, callback) => {
+          if (callback) {
+            callback({ totalBytesWritten: 0, totalBytesExpectedToWrite: 0 });
+          }
+          return { downloadAsync: mockDownloadAsync };
+        }
+      );
+
+      await downloadFile({
+        url: 'https://example.com/video.mp4',
+        onProgress,
+      });
+
+      expect(onProgress).not.toHaveBeenCalled();
+    });
+
+    it('should throw DOWNLOAD_FAILED when downloadAsync resolves to undefined', async () => {
+      const mockDownloadAsync = jest.fn().mockResolvedValue(undefined);
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      await expect(
+        downloadFile('https://example.com/image.jpg')
+      ).rejects.toMatchObject({ code: 'DOWNLOAD_FAILED' });
+    });
+
+    it('should wrap network errors as UNKNOWN_ERROR preserving the message', async () => {
+      const mockDownloadAsync = jest
+        .fn()
+        .mockRejectedValue(new Error('Network request failed'));
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      await expect(
+        downloadFile('https://example.com/image.jpg')
+      ).rejects.toMatchObject({
+        code: 'UNKNOWN_ERROR',
+        message: 'Network request failed',
+      });
+    });
+
+    it('should wrap non-Error rejections with a fallback message', async () => {
+      const mockDownloadAsync = jest.fn().mockRejectedValue('boom');
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      await expect(
+        downloadFile('https://example.com/image.jpg')
+      ).rejects.toMatchObject({
+        code: 'UNKNOWN_ERROR',
+        message: 'An unknown error occurred',
+      });
+    });
+
+    it('should wrap getInfoAsync failures during cache lookup', async () => {
+      (FileSystem.getInfoAsync as jest.Mock).mockRejectedValue(
+        new Error('Disk unavailable')
+      );
+
+      await expect(
+        downloadFile({ url: 'https://example.com/image.jpg', cache: true })
+      ).rejects.toMatchObject({
+        code: 'UNKNOWN_ERROR',
+        message: 'Disk unavailable',
+      });
+    });
+
+    it('should request write-only media library permission', async () => {
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/test.jpg',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+      });
+
+      (MediaLibrary.createAssetAsync as jest.Mock).mockResolvedValue({
+        id: 'asset-123',
+      });
+
+      (MediaLibrary.getAlbumAsync as jest.Mock).mockResolvedValue({
+        id: 'album-123',
+      });
+
+      await downloadFile({
+        url: 'https://example.com/image.jpg',
+        saveToGallery: true,
+      });
+
+      expect(MediaLibrary.requestPermissionsAsync).toHaveBeenCalledWith(true);
+    });
+
+    it('should add asset to an existing album without copying', async () => {
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/test.jpg',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+      });
+
+      const mockAsset = { id: 'asset-123' };
+      const mockAlbum = { id: 'album-123' };
+      (MediaLibrary.createAssetAsync as jest.Mock).mockResolvedValue(mockAsset);
+      (MediaLibrary.getAlbumAsync as jest.Mock).mockResolvedValue(mockAlbum);
+
+      await downloadFile({
+        url: 'https://example.com/image.jpg',
+        saveToGallery: true,
+      });
+
+      expect(MediaLibrary.addAssetsToAlbumAsync).toHaveBeenCalledWith(
+        [mockAsset],
+        mockAlbum,
+        false
+      );
+      expect(MediaLibrary.createAlbumAsync).not.toHaveBeenCalled();
+    });
+
+    it('should wrap media library failures after a successful download', async () => {
+      const mockDownloadAsync = jest.fn().mockResolvedValue({
+        uri: 'file:///mock/document/test.jpg',
+      });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      (MediaLibrary.requestPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+      });
+
+      (MediaLibrary.createAssetAsync as jest.Mock).mockRejectedValue(
+        new Error('This file type is not supported yet')
+      );
+
+      await expect(
+        downloadFile({
+          url: 'https://example.com/file.pdf',
+          saveToGallery: true,
+        })
+      ).rejects.toMatchObject({
+        code: 'UNKNOWN_ERROR',
+        message: 'This file type is not supported yet',
+      });
+    });
   });
 
   describe('useDownload', () => {
@@ -514,6 +763,132 @@ describe('expodl', () => {
       });
 
       expect(result.current.error?.code).toBe('CANCELLED');
+    });
+
+    it('should report CANCELLED when downloadAsync resolves undefined after cancel', async () => {
+      // Legacy downloadAsync resolves to undefined when the task was cancelled
+      const mockCancelAsync = jest.fn().mockResolvedValue(undefined);
+      let resolveDownload: (value: unknown) => void = () => {};
+      const mockDownloadAsync = jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveDownload = resolve;
+          })
+      );
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+        cancelAsync: mockCancelAsync,
+      });
+
+      const { result } = renderHook(() => useDownload());
+
+      let downloadPromise: Promise<void> = Promise.resolve();
+      act(() => {
+        downloadPromise = result.current.download(
+          'https://example.com/image.jpg'
+        );
+        downloadPromise.catch(() => {});
+      });
+
+      act(() => {
+        result.current.cancel();
+      });
+
+      await act(async () => {
+        resolveDownload(undefined);
+        await downloadPromise.catch(() => {});
+      });
+
+      expect(result.current.error?.code).toBe('CANCELLED');
+      await expect(downloadPromise).rejects.toMatchObject({
+        code: 'CANCELLED',
+      });
+    });
+
+    it('should ignore cancel when no download is active', () => {
+      const { result } = renderHook(() => useDownload());
+
+      act(() => {
+        result.current.cancel();
+      });
+
+      expect(result.current.error).toBe(null);
+      expect(result.current.isDownloading).toBe(false);
+    });
+
+    it('should allow a fresh download after cancellation', async () => {
+      const mockCancelAsync = jest.fn().mockResolvedValue(undefined);
+      let rejectFirst: (err: Error) => void = () => {};
+      const mockDownloadAsync = jest
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise((_resolve, reject) => {
+              rejectFirst = reject;
+            })
+        )
+        .mockResolvedValueOnce({ uri: 'file:///mock/document/second.jpg' });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+        cancelAsync: mockCancelAsync,
+      });
+
+      const { result } = renderHook(() => useDownload());
+
+      let firstDownload: Promise<void> = Promise.resolve();
+      act(() => {
+        firstDownload = result.current.download('https://example.com/a.jpg');
+        firstDownload.catch(() => {});
+      });
+
+      act(() => {
+        result.current.cancel();
+      });
+
+      await act(async () => {
+        rejectFirst(new Error('aborted'));
+        await firstDownload.catch(() => {});
+      });
+
+      expect(result.current.error?.code).toBe('CANCELLED');
+
+      await act(async () => {
+        await result.current.download('https://example.com/b.jpg');
+      });
+
+      expect(result.current.error).toBe(null);
+      expect(result.current.result).toHaveProperty('uri');
+      expect(result.current.isDownloading).toBe(false);
+    });
+
+    it('should clear previous error state when starting a new download', async () => {
+      const mockDownloadAsync = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({ uri: 'file:///mock/document/retry.jpg' });
+
+      (FileSystem.createDownloadResumable as jest.Mock).mockReturnValue({
+        downloadAsync: mockDownloadAsync,
+      });
+
+      const { result } = renderHook(() => useDownload());
+
+      await act(async () => {
+        await result.current
+          .download('https://example.com/image.jpg')
+          .catch(() => {});
+      });
+
+      expect(result.current.error?.code).toBe('UNKNOWN_ERROR');
+
+      await act(async () => {
+        await result.current.download('https://example.com/image.jpg');
+      });
+
+      expect(result.current.error).toBe(null);
+      expect(result.current.result).toHaveProperty('uri');
     });
 
     it('should use custom headers', async () => {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -25,7 +25,7 @@ jest.mock('expo-media-library', () => ({
 import * as FileSystem from 'expo-file-system/legacy';
 import * as MediaLibrary from 'expo-media-library';
 
-describe('expodl', () => {
+describe('expo-download', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,8 @@ function generateFileName(url: string, customName?: string): string {
 }
 
 async function saveToMediaLibrary(uri: string, albumName: string) {
-  const { status } = await MediaLibrary.requestPermissionsAsync();
+  // writeOnly: saving is the only media library operation performed
+  const { status } = await MediaLibrary.requestPermissionsAsync(true);
 
   if (status !== 'granted') {
     throw new DownloadError(
@@ -107,8 +108,17 @@ async function performDownload(
     throw new DownloadError('URL is required', 'INVALID_URL');
   }
 
+  // documentDirectory is null on platforms without a writable directory (web)
+  const directory = FileSystem.documentDirectory;
+  if (!directory) {
+    throw new DownloadError(
+      'No writable document directory available on this platform',
+      'UNAVAILABLE'
+    );
+  }
+
   const fileName = generateFileName(url, customFileName);
-  const fileUri = `${FileSystem.documentDirectory}${fileName}`;
+  const fileUri = `${directory}${fileName}`;
   const extension = getFileExtension(url);
   const mimeType = getMimeType(extension);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import * as MediaLibrary from 'expo-media-library';
 
 export interface DownloadOptions {
@@ -10,14 +10,12 @@ export interface DownloadOptions {
   onProgress?: (progress: number) => void;
   headers?: Record<string, string>;
   cache?: boolean;
-  overwrite?: boolean;
 }
 
 export interface DownloadResult {
   uri: string;
   fileName: string;
   mimeType: string | null;
-  size?: number;
   cached?: boolean;
 }
 
@@ -71,6 +69,100 @@ function generateFileName(url: string, customName?: string): string {
   return `download_${timestamp}.${extension}`;
 }
 
+async function saveToMediaLibrary(uri: string, albumName: string) {
+  const { status } = await MediaLibrary.requestPermissionsAsync();
+
+  if (status !== 'granted') {
+    throw new DownloadError(
+      'Media library permission denied',
+      'PERMISSION_DENIED'
+    );
+  }
+
+  const asset = await MediaLibrary.createAssetAsync(uri);
+  const album = await MediaLibrary.getAlbumAsync(albumName);
+
+  if (album === null) {
+    await MediaLibrary.createAlbumAsync(albumName, asset, false);
+  } else {
+    await MediaLibrary.addAssetsToAlbumAsync([asset], album, false);
+  }
+}
+
+async function performDownload(
+  options: DownloadOptions,
+  onResumableCreated?: (resumable: FileSystem.DownloadResumable) => void
+): Promise<DownloadResult> {
+  const {
+    url,
+    fileName: customFileName,
+    saveToGallery = false,
+    albumName = 'Download',
+    onProgress,
+    headers,
+    cache = false,
+  } = options;
+
+  if (!url) {
+    throw new DownloadError('URL is required', 'INVALID_URL');
+  }
+
+  const fileName = generateFileName(url, customFileName);
+  const fileUri = `${FileSystem.documentDirectory}${fileName}`;
+  const extension = getFileExtension(url);
+  const mimeType = getMimeType(extension);
+
+  // Reuse existing file when caching is enabled
+  if (cache) {
+    const fileInfo = await FileSystem.getInfoAsync(fileUri);
+    if (fileInfo.exists) {
+      return {
+        uri: fileUri,
+        fileName,
+        mimeType,
+        cached: true,
+      };
+    }
+  }
+
+  const downloadResumable = FileSystem.createDownloadResumable(
+    url,
+    fileUri,
+    headers ? { headers } : {},
+    onProgress
+      ? (downloadProgress) => {
+          const { totalBytesWritten, totalBytesExpectedToWrite } =
+            downloadProgress;
+          // totalBytesExpectedToWrite is -1 when the server omits Content-Length
+          if (totalBytesExpectedToWrite > 0) {
+            onProgress(
+              Math.min(totalBytesWritten / totalBytesExpectedToWrite, 1)
+            );
+          }
+        }
+      : undefined
+  );
+
+  onResumableCreated?.(downloadResumable);
+
+  const downloadResult = await downloadResumable.downloadAsync();
+
+  if (!downloadResult) {
+    throw new DownloadError('Download failed', 'DOWNLOAD_FAILED');
+  }
+
+  if (saveToGallery) {
+    await saveToMediaLibrary(downloadResult.uri, albumName);
+  }
+
+  return {
+    uri: downloadResult.uri,
+    fileName,
+    mimeType,
+    cached: false,
+  };
+}
+
 /**
  * Download file from URL
  */
@@ -79,97 +171,10 @@ export async function downloadFile(
 ): Promise<DownloadResult> {
   // Handle both string URL and options object
   const options: DownloadOptions =
-    typeof urlOrOptions === 'string'
-      ? { url: urlOrOptions, saveToGallery: true }
-      : urlOrOptions;
-
-  const {
-    url,
-    fileName: customFileName,
-    saveToGallery = true,
-    albumName = 'Download',
-    onProgress,
-    headers,
-    cache = false,
-    overwrite = true,
-  } = options;
-
-  if (!url) {
-    throw new DownloadError('URL is required', 'INVALID_URL');
-  }
+    typeof urlOrOptions === 'string' ? { url: urlOrOptions } : urlOrOptions;
 
   try {
-    const fileName = generateFileName(url, customFileName);
-    const fileUri = `${FileSystem.documentDirectory}${fileName}`;
-    const extension = getFileExtension(url);
-    const mimeType = getMimeType(extension);
-
-    // Check if file exists (cache control)
-    if (cache && !overwrite) {
-      const fileInfo = await FileSystem.getInfoAsync(fileUri);
-      if (fileInfo.exists) {
-        return {
-          uri: fileUri,
-          fileName,
-          mimeType,
-          cached: true,
-        };
-      }
-    }
-
-    // Create download resumable for progress tracking
-    const downloadResumable = FileSystem.createDownloadResumable(
-      url,
-      fileUri,
-      headers ? { headers } : {},
-      onProgress
-        ? (downloadProgress) => {
-            const progress =
-              downloadProgress.totalBytesWritten /
-              downloadProgress.totalBytesExpectedToWrite;
-            onProgress(progress);
-          }
-        : undefined
-    );
-
-    const downloadResult = await downloadResumable.downloadAsync();
-
-    if (!downloadResult) {
-      throw new DownloadError('Download failed', 'DOWNLOAD_FAILED');
-    }
-
-    const result: DownloadResult = {
-      uri: downloadResult.uri,
-      fileName,
-      mimeType,
-      cached: false,
-    };
-
-    // Save to gallery if requested
-    if (saveToGallery) {
-      // Request permissions
-      const { status } = await MediaLibrary.requestPermissionsAsync();
-
-      if (status !== 'granted') {
-        throw new DownloadError(
-          'Media library permission denied',
-          'PERMISSION_DENIED'
-        );
-      }
-
-      // Create asset from downloaded file
-      const asset = await MediaLibrary.createAssetAsync(downloadResult.uri);
-
-      // Create or get album
-      const album = await MediaLibrary.getAlbumAsync(albumName);
-      if (album === null) {
-        await MediaLibrary.createAlbumAsync(albumName, asset, false);
-      } else {
-        await MediaLibrary.addAssetsToAlbumAsync([asset], album, false);
-      }
-    }
-
-    return result;
+    return await performDownload(options);
   } catch (error: any) {
     if (error instanceof DownloadError) {
       throw error;
@@ -191,7 +196,6 @@ export interface UseDownloadOptions {
   fileName?: string;
   headers?: Record<string, string>;
   cache?: boolean;
-  overwrite?: boolean;
 }
 
 export interface UseDownloadReturn {
@@ -230,6 +234,7 @@ export function useDownload(
   const downloadResumableRef = useRef<FileSystem.DownloadResumable | null>(
     null
   );
+  const cancelledRef = useRef(false);
 
   const reset = useCallback(() => {
     setIsDownloading(false);
@@ -237,12 +242,17 @@ export function useDownload(
     setError(null);
     setResult(null);
     downloadResumableRef.current = null;
+    cancelledRef.current = false;
   }, []);
 
   const cancel = useCallback(() => {
-    if (downloadResumableRef.current) {
-      downloadResumableRef.current.pauseAsync();
+    const resumable = downloadResumableRef.current;
+    if (resumable) {
+      cancelledRef.current = true;
       downloadResumableRef.current = null;
+      resumable.cancelAsync().catch(() => {
+        // Cancellation errors are irrelevant; the download is being discarded
+      });
       setIsDownloading(false);
       setError(new DownloadError('Download cancelled', 'CANCELLED'));
     }
@@ -254,94 +264,31 @@ export function useDownload(
       setProgress(0);
       setError(null);
       setResult(null);
+      cancelledRef.current = false;
 
       try {
-        const fileName = generateFileName(
-          url,
-          options?.fileName ?? defaultOptions?.fileName
-        );
-        const fileUri = `${FileSystem.documentDirectory}${fileName}`;
-        const extension = getFileExtension(url);
-        const mimeType = getMimeType(extension);
-
-        // Check cache
-        const cache = options?.cache ?? defaultOptions?.cache ?? false;
-        const overwrite =
-          options?.overwrite ?? defaultOptions?.overwrite ?? true;
-
-        if (cache && !overwrite) {
-          const fileInfo = await FileSystem.getInfoAsync(fileUri);
-          if (fileInfo.exists) {
-            setResult({
-              uri: fileUri,
-              fileName,
-              mimeType,
-              cached: true,
-            });
-            setIsDownloading(false);
-            return;
-          }
-        }
-
-        // Create download resumable
-        const headers = options?.headers ?? defaultOptions?.headers;
-        const downloadResumable = FileSystem.createDownloadResumable(
-          url,
-          fileUri,
-          headers ? { headers } : {},
-          (downloadProgress) => {
-            const p =
-              downloadProgress.totalBytesWritten /
-              downloadProgress.totalBytesExpectedToWrite;
-            setProgress(p);
+        const finalResult = await performDownload(
+          {
+            url,
+            fileName: options?.fileName ?? defaultOptions?.fileName,
+            saveToGallery:
+              options?.saveToGallery ?? defaultOptions?.saveToGallery,
+            albumName: options?.albumName ?? defaultOptions?.albumName,
+            headers: options?.headers ?? defaultOptions?.headers,
+            cache: options?.cache ?? defaultOptions?.cache,
+            onProgress: setProgress,
+          },
+          (resumable) => {
+            downloadResumableRef.current = resumable;
           }
         );
-
-        downloadResumableRef.current = downloadResumable;
-
-        const downloadResult = await downloadResumable.downloadAsync();
-
-        if (!downloadResult) {
-          throw new DownloadError('Download failed', 'DOWNLOAD_FAILED');
-        }
-
-        const finalResult: DownloadResult = {
-          uri: downloadResult.uri,
-          fileName,
-          mimeType,
-          cached: false,
-        };
-
-        // Save to gallery if requested
-        const saveToGallery =
-          options?.saveToGallery ?? defaultOptions?.saveToGallery ?? true;
-        if (saveToGallery) {
-          const { status } = await MediaLibrary.requestPermissionsAsync();
-
-          if (status !== 'granted') {
-            throw new DownloadError(
-              'Media library permission denied',
-              'PERMISSION_DENIED'
-            );
-          }
-
-          const asset = await MediaLibrary.createAssetAsync(downloadResult.uri);
-          const albumName =
-            options?.albumName ?? defaultOptions?.albumName ?? 'Download';
-          const album = await MediaLibrary.getAlbumAsync(albumName);
-
-          if (album === null) {
-            await MediaLibrary.createAlbumAsync(albumName, asset, false);
-          } else {
-            await MediaLibrary.addAssetsToAlbumAsync([asset], album, false);
-          }
-        }
 
         setResult(finalResult);
         downloadResumableRef.current = null;
       } catch (err: any) {
-        const downloadError =
-          err instanceof DownloadError
+        const downloadError = cancelledRef.current
+          ? new DownloadError('Download cancelled', 'CANCELLED')
+          : err instanceof DownloadError
             ? err
             : new DownloadError(
                 err.message || 'An unknown error occurred',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "expodl": ["./src/index"]
+      "expo-download": ["./src/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
## Summary

Major release (2.0.0 via release-please). Modernizes the package for current Expo and fixes a bug that could break consumer installs.

### Install fix
- Removed `postinstall: patch-package` from published scripts. `patch-package` was only a devDependency and no `patches/` directory exists, so consumer `npm install expodl` could fail with `patch-package: command not found`.

### Expo SDK 54+ support
- `expo-file-system` and `expo-media-library` moved from `dependencies` to `peerDependencies` (no more nested duplicate native modules in consumer apps).
- Source now imports from `expo-file-system/legacy` — required on SDK 54+, where `documentDirectory` / `createDownloadResumable` were removed from the main entry. Verified the `./legacy` subpath still ships in expo-file-system v57 (SDK 57).

### Breaking API changes
- `saveToGallery` defaults to `false` (media library rejects non-media files like PDFs; opting in is now explicit).
- `overwrite` option removed — `cache: true` alone reuses an existing file.
- `cancel()` now calls `cancelAsync()` (real cancellation, not pause); the pending `download()` promise rejects with code `CANCELLED`.
- `DownloadResult.size` removed (was never populated).
- Peer ranges: `expo-file-system >=19`, `expo-media-library >=17`, `react >=18`, `react-native >=0.76`.

### Fixes
- Progress callback no longer produces negative/NaN values when the server omits `Content-Length` (`totalBytesExpectedToWrite === -1`).
- Cancelling no longer leaves the hook error state as `UNKNOWN_ERROR` when the native rejection lands.

### Housekeeping
- Deduplicated download logic shared by `downloadFile` and `useDownload`.
- devDeps: React 19.1.0 / react-test-renderer 19.1.0, `@types/react` 19, dropped `patch-package`/`postinstall-postinstall`, added expo packages for typechecking; removed stale `resolutions`/`overrides` pins.
- Example app bumped to Expo SDK 54 (deps only — not run on a device as part of this PR).
- README/docs updated with migration guide.

## Testing
- `jest`: 23/23 pass (including new tests for cache semantics, unknown-Content-Length progress, real cancellation)
- `tsc --noEmit`: clean
- `eslint`: clean
- `bob build`: clean
- `npm pack --dry-run`: tarball no longer ships `postinstall`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Rename (added in follow-up commits)
- Package renamed `expodl` → `expo-download` (matches search terms and community `expo-*` convention; name and punctuation variants verified free on npm). GitHub repo renamed to match; old URLs redirect.
- After 2.0.0 publishes: run `npm deprecate expodl@"*" "Renamed to expo-download"`.

### Test hardening (added in follow-up commits)
- 23 → 39 tests. New coverage: progress clamping/zero/unknown Content-Length, undefined `downloadAsync` result after cancel, cancel with no active download, fresh download after cancel, error-state reset, non-Error rejections, media-library failure wrapping, write-only permission arg, `documentDirectory` null → new `UNAVAILABLE` error code.
- Verified against expo-file-system v57 legacy source: `cancelAsync` semantics, `-1` Content-Length behavior, `/legacy` subpath resolution on v19 (root `legacy.ts` re-export).

