### PR TITLE
fix: rename package to expodownload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 # Changelog
 
-## [2.0.0](https://github.com/pavankommi/expo-download/compare/v1.0.3...v2.0.0) (2026-07-12)
+## [2.0.0](https://github.com/pavankommi/expodownload/compare/v1.0.3...v2.0.0) (2026-07-12)
 
 
 ### ⚠ BREAKING CHANGES
 
-* the package is now published as expo-download; expodl is deprecated. The expo- prefix matches community convention and what people actually search for. 1.x remains available as expodl.
+* the package is now published as expodownload; expodl is deprecated. The expo- prefix matches community convention and what people actually search for. 1.x remains available as expodl.
 * requires Expo SDK 54+ (expo-file-system >=19, expo-media-library >=17), React 18+, and React Native 0.76+. expo-file-system and expo-media-library are now peerDependencies and must be installed by the consuming app. saveToGallery now defaults to false. The overwrite option is removed; cache: true alone reuses an existing file. cancel() now cancels the download instead of pausing it, and the pending download() promise rejects with code CANCELLED. DownloadResult.size is removed (it was never populated).
 
 ### Features
 
-* modernize for Expo SDK 54+, fix consumer install failure ([68f7f60](https://github.com/pavankommi/expo-download/commit/68f7f600bd55600bc16adb9e9bb660918e6da8ef))
-* rename package to expo-download ([3742e41](https://github.com/pavankommi/expo-download/commit/3742e416143add0d67552fd572a9c1ae4bfd8e72))
+* modernize for Expo SDK 54+, fix consumer install failure ([68f7f60](https://github.com/pavankommi/expodownload/commit/68f7f600bd55600bc16adb9e9bb660918e6da8ef))
+* rename package to expodownload ([3742e41](https://github.com/pavankommi/expodownload/commit/3742e416143add0d67552fd572a9c1ae4bfd8e72))
 
 ## [1.0.3](https://github.com/pavankommi/expodl/compare/v1.0.2...v1.0.3) (2025-10-31)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# expo-download
+# expodownload
 
 > Lightweight Expo file download utility with caching, cancellation, and headers support.
 
-[![npm version](https://badge.fury.io/js/expo-download.svg)](https://www.npmjs.com/package/expo-download)
-[![npm downloads](https://img.shields.io/npm/dm/expo-download.svg)](https://www.npmjs.com/package/expo-download)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/expo-download)](https://bundlephobia.com/package/expo-download)
-[![license](https://img.shields.io/npm/l/expo-download.svg)](https://github.com/pavankommi/expo-download/blob/main/LICENSE)
+[![npm version](https://badge.fury.io/js/expodownload.svg)](https://www.npmjs.com/package/expodownload)
+[![npm downloads](https://img.shields.io/npm/dm/expodownload.svg)](https://www.npmjs.com/package/expodownload)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/expodownload)](https://bundlephobia.com/package/expodownload)
+[![license](https://img.shields.io/npm/l/expodownload.svg)](https://github.com/pavankommi/expodownload/blob/main/LICENSE)
 
 ## Features
 
@@ -17,7 +17,7 @@
 ## Installation
 
 ```sh
-npx expo install expo-download expo-file-system expo-media-library
+npx expo install expodownload expo-file-system expo-media-library
 ```
 
 `expo-file-system` and `expo-media-library` are peer dependencies — installing them with `npx expo install` ensures the versions match your Expo SDK.
@@ -25,7 +25,7 @@ npx expo install expo-download expo-file-system expo-media-library
 ## Quick Start
 
 ```typescript
-import { useDownload } from 'expo-download';
+import { useDownload } from 'expodownload';
 
 export default function App() {
   const { download, isDownloading, progress, cancel } = useDownload();
@@ -86,7 +86,7 @@ await download('https://example.com/photo.jpg');
 ### Function API (Advanced)
 
 ```typescript
-import { downloadFile } from 'expo-download';
+import { downloadFile } from 'expodownload';
 
 const result = await downloadFile({
   url: 'https://example.com/file.pdf',
@@ -105,7 +105,7 @@ For Expo SDK 53 and below, use `expodl@1.x` (this package's previous name).
 
 ## Migrating from 1.x
 
-- **Package renamed from `expodl` to `expo-download`.** Uninstall `expodl` and install `expo-download`; imports change accordingly.
+- **Package renamed from `expodl` to `expodownload`.** Uninstall `expodl` and install `expodownload`; imports change accordingly.
 - **`saveToGallery` now defaults to `false`.** Downloads land in the app's document directory unless you opt in. Pass `saveToGallery: true` to keep the old behavior (media files only).
 - **`overwrite` option removed.** `cache: true` alone now reuses an existing file; omit it to always re-download.
 - **`expo-file-system` and `expo-media-library` are peer dependencies.** Install them in your app with `npx expo install`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete API documentation for expo-download.
+Complete API documentation for expodownload.
 
 ## Table of Contents
 
@@ -131,7 +131,7 @@ Throws `DownloadError` with specific error codes. See [Error Handling](#error-ha
 ### Example
 
 ```typescript
-import { downloadFile } from 'expo-download';
+import { downloadFile } from 'expodownload';
 
 // Simple download
 const result = await downloadFile('https://example.com/image.jpg');
@@ -295,7 +295,7 @@ try {
 **With Function:**
 
 ```typescript
-import { downloadFile, DownloadError } from 'expo-download';
+import { downloadFile, DownloadError } from 'expodownload';
 
 try {
   await downloadFile('https://example.com/file.pdf');
@@ -322,7 +322,7 @@ try {
 
 ## Supported File Types
 
-expo-download automatically detects MIME types for common file extensions:
+expodownload automatically detects MIME types for common file extensions:
 
 | Extension | MIME Type |
 |-----------|-----------|

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-Advanced usage examples for expo-download.
+Advanced usage examples for expodownload.
 
 ## Table of Contents
 
@@ -20,7 +20,7 @@ Advanced usage examples for expo-download.
 Allow users to cancel downloads mid-flight:
 
 ```typescript
-import { useDownload } from 'expo-download';
+import { useDownload } from 'expodownload';
 
 function DownloadWithCancel() {
   const { download, cancel, isDownloading, progress } = useDownload();
@@ -48,7 +48,7 @@ function DownloadWithCancel() {
 Download files from protected APIs:
 
 ```typescript
-import { useDownload } from 'expo-download';
+import { useDownload } from 'expodownload';
 
 function AuthenticatedDownload() {
   const { download } = useDownload({
@@ -83,7 +83,7 @@ await download('https://api.example.com/file.pdf', {
 Avoid re-downloading files that already exist:
 
 ```typescript
-import { useDownload } from 'expo-download';
+import { useDownload } from 'expodownload';
 
 function CachedDownload() {
   const { download, result } = useDownload({
@@ -119,7 +119,7 @@ function CachedDownload() {
 Track multiple downloads independently:
 
 ```typescript
-import { useDownload } from 'expo-download';
+import { useDownload } from 'expodownload';
 
 function MultiDownload() {
   const images = useDownload();
@@ -150,7 +150,7 @@ function MultiDownload() {
 Properly handle download errors:
 
 ```typescript
-import { useDownload, DownloadError } from 'expo-download';
+import { useDownload, DownloadError } from 'expodownload';
 
 function SafeDownload() {
   const { download, isDownloading, error, reset } = useDownload();
@@ -201,7 +201,7 @@ function SafeDownload() {
 Build a download manager:
 
 ```typescript
-import { useDownload } from 'expo-download';
+import { useDownload } from 'expodownload';
 import { useState } from 'react';
 
 function DownloadList() {
@@ -253,7 +253,7 @@ function DownloadList() {
 Organize gallery downloads into specific albums with custom names:
 
 ```typescript
-import { useDownload } from 'expo-download';
+import { useDownload } from 'expodownload';
 
 function OrganizedDownload() {
   const { download } = useDownload({
@@ -283,7 +283,7 @@ function OrganizedDownload() {
 By default, files are saved only to the app's document directory. Opt in to also save media to the device gallery:
 
 ```typescript
-import { useDownload } from 'expo-download';
+import { useDownload } from 'expodownload';
 
 function GalleryDownload() {
   const { download, result } = useDownload();
@@ -313,7 +313,7 @@ function GalleryDownload() {
 For more control, use `downloadFile` directly:
 
 ```typescript
-import { downloadFile } from 'expo-download';
+import { downloadFile } from 'expodownload';
 
 async function advancedDownload() {
   const result = await downloadFile({
@@ -346,7 +346,7 @@ Here's a full-featured download component:
 ```typescript
 import React, { useState } from 'react';
 import { View, Button, Text, ActivityIndicator, StyleSheet } from 'react-native';
-import { useDownload } from 'expo-download';
+import { useDownload } from 'expodownload';
 
 export default function DownloadManager() {
   const {
@@ -360,7 +360,7 @@ export default function DownloadManager() {
   } = useDownload({
     cache: true,
     headers: {
-      'User-Agent': 'expo-download-example'
+      'User-Agent': 'expodownload-example'
     }
   });
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,7 +7,7 @@ import {
   Button,
   ActivityIndicator,
 } from 'react-native';
-import { useDownload } from 'expo-download';
+import { useDownload } from 'expodownload';
 
 export default function App() {
   const { download, cancel, isDownloading, progress, error, result, reset } =
@@ -19,7 +19,7 @@ export default function App() {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>expo-download Example</Text>
+      <Text style={styles.title}>expodownload Example</Text>
       <Text style={styles.subtitle}>Download with cancellation</Text>
 
       {!isDownloading && !result && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "expo-download",
+  "name": "expodownload",
   "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "expo-download",
+      "name": "expodownload",
       "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "expo-download",
+  "name": "expodownload",
   "version": "2.0.0",
   "description": "Lightweight Expo file download utility with caching, cancellation, and headers support.",
   "main": "lib/commonjs/index",
@@ -47,13 +47,13 @@
     "expo-file-system",
     "expo-media-library"
   ],
-  "repository": "https://github.com/pavankommi/expo-download",
+  "repository": "https://github.com/pavankommi/expodownload",
   "author": "pavankommi <pavankommi0503@gmail.com> (https://github.com/pavankommi)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/pavankommi/expo-download/issues"
+    "url": "https://github.com/pavankommi/expodownload/issues"
   },
-  "homepage": "https://github.com/pavankommi/expo-download#readme",
+  "homepage": "https://github.com/pavankommi/expodownload#readme",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -25,7 +25,7 @@ jest.mock('expo-media-library', () => ({
 import * as FileSystem from 'expo-file-system/legacy';
 import * as MediaLibrary from 'expo-media-library';
 
-describe('expo-download', () => {
+describe('expodownload', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "expo-download": ["./src/index"]
+      "expodownload": ["./src/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
npm blocklists new unscoped `expo-*` package names (`400 That word is not allowed`), so `expo-download@2.0.0` failed to publish. Single-word `expodownload` follows the same pattern as the original `expodl` and passes the filter.

Repo renamed to match; old URLs redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)